### PR TITLE
Change background to solid black

### DIFF
--- a/assets/sass/main.scss
+++ b/assets/sass/main.scss
@@ -28,7 +28,7 @@ $dark-toc-bg: #323232;
 $dark-go-top-bg: #676767b3;
 $dark-go-top-bg-hover: #676767;
 
-$dark-black: #131418;
+$dark-black: #000;
 $dark-white: #eaeaea;
 $dark-light: #1b1d25;
 $dark-smoke: #4a4d56;


### PR DESCRIPTION
This PR changes the dark theme background color to solid black (#000) instead of the previous dark gray (#131418). This provides a more dramatic dark theme with better contrast.